### PR TITLE
add some missing upstream functions

### DIFF
--- a/src/console.h
+++ b/src/console.h
@@ -10,4 +10,38 @@
 #define logFatal(FORMAT, ARGS...) do { LOG_FATAL(FORMAT, ## ARGS); } while(0)
 #define logInform(FORMAT, ARGS...) do { LOG_INFO(FORMAT, ## ARGS); } while(0)
 
+
+/** \brief Message namespace. This contains classes needed to
+    output error messages (or logging) from within the library.
+    Message logging can be performed with \ref logging "logging macros" */
+namespace console_bridge
+{
+/** \brief The set of priorities for message logging */
+enum LogLevel
+  {
+    CONSOLE_BRIDGE_LOG_DEBUG = 0,
+    CONSOLE_BRIDGE_LOG_INFO,
+    CONSOLE_BRIDGE_LOG_WARN,
+    CONSOLE_BRIDGE_LOG_ERROR,
+    CONSOLE_BRIDGE_LOG_NONE
+  };
+
+
+/** \brief Set the minimum level of logging data to output.  Messages
+    with lower logging levels will not be recorded. */
+inline void setLogLevel(LogLevel level)
+{
+    logWarn("The rock implementation of console_bridge does not support setLogLevel()!");
+}
+
+/** \brief Retrieve the current level of logging data.  Messages
+    with lower logging levels will not be recorded. */
+inline LogLevel getLogLevel(void)
+{
+    logWarn("The rock implementation of console_bridge does not support getLogLevel()!");
+    return CONSOLE_BRIDGE_LOG_INFO;
+}
+
+} // namespace console_bridge
+
 #endif


### PR DESCRIPTION
Copied some missing parts of the public API from here: https://github.com/ros/console_bridge to enable compilation of code that uses LogLevel, setLogLevel() or getLogLevel()
